### PR TITLE
[Typo] fixed: change link title

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,7 +62,7 @@ code > span.in { color: #60a0b0; font-weight: bold; font-style: italic; } /* Inf
 <p>
 <h3>
 Warning: 请与
-<a href="https://github.com/phodal/growth-in-action-django">《Growth：全栈增长工程师指南》</a> 一起阅读
+<a href="https://github.com/phodal/growth-in-action-django">《Growth：全栈增长工程师实战》</a> 一起阅读
 </h3>
 <p>
 阅读过程中遇到语法错误、拼写错误、技术错误等等，不妨来个Pull Request，这样可以帮助到其他阅读这本电子书的童鞋。


### PR DESCRIPTION
typo小错误，应该是实战那本书，链接是对的。
